### PR TITLE
add Notion connection url to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ https://github.com/hirakuuuu/AtCoderToNotion/assets/83483542/55d894d2-a560-48d5-
    
 4. Integrationとデータベースの紐づけ
    - データベースを置いているページに先ほど作成したインテグレーションを追加してください
+   - [インテグレーションの追加と管理 – Notion (ノーション)ヘルプセンター](https://www.notion.com/ja/help/add-and-manage-connections-with-the-api)
 
 ## 拡張機能の導入
 


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change adds a helpful link to the Notion Help Center for managing integrations.

Documentation update:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R33): Added a link to the Notion Help Center for guidance on adding and managing integrations.